### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An MCP server that provides tools to fetch and search news from The Verge's RSS feed.
 
+<a href="https://glama.ai/mcp/servers/n6lbwdnbxa">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/n6lbwdnbxa/badge" alt="The Verge News Server MCP server" />
+</a>
+
 ## Features
 
 - Fetch today's news from The Verge


### PR DESCRIPTION
This PR adds a badge for the [The Verge News MCP Server](https://glama.ai/mcp/servers/n6lbwdnbxa) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/n6lbwdnbxa">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/n6lbwdnbxa/badge" alt="The Verge News Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.